### PR TITLE
Issue/69 exp bar

### DIFF
--- a/src/lib/components/CareerExp.svelte
+++ b/src/lib/components/CareerExp.svelte
@@ -49,7 +49,7 @@
             </div>
             
             <div>
-                {daysLeft} / {numDaysBetweenAnniversaries}
+                {daysLeft} / {numDaysBetweenAnniversaries} days
             </div>
         </div>
     </div>

--- a/src/lib/components/EnvironmentImg.svelte
+++ b/src/lib/components/EnvironmentImg.svelte
@@ -5,12 +5,13 @@
 
 <div class="environment-img">
     <img src="{src}" alt="{alt}" />
-</div>
+</div>  
 
 <style>
     .environment-img {
         width: 100%;
         max-width: 80rem;
+        min-height: 10rem;
         margin: 0 auto;
         overflow: hidden;
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -104,6 +104,8 @@
 
 <div class="app">
     <header>
+        <CareerExp />
+
         <div class="nav-container">
             <div class="top">
                 <div class="side left"></div>
@@ -138,8 +140,6 @@
                 <div class="bottom-row" bind:this={bottomRowNavRef}></div>
             </nav>
         </div>
-
-        <CareerExp />
     </header>
 
     <main>
@@ -187,6 +187,7 @@
         align-items: center;
         gap: 0.5rem;
         width: 100%;
+        padding-bottom: 1.5rem;
 
         @media(min-width: 590px) {
             gap: 1rem;
@@ -202,7 +203,7 @@
         display: flex;
         justify-content: space-between;
         width: 100%;
-        padding: 1.5rem 1.5rem 1rem;
+        padding: 1rem 1.5rem;
 
         &:before {
             content: '';


### PR DESCRIPTION
Resolves #69 

moves the `CareerExp` component to the top of header to prevent exp data from overlapping `EnvironmentImg`.